### PR TITLE
Fix admin profile menu consistency and data

### DIFF
--- a/app/Http/Controllers/Admin/IndikatorKelulusanController.php
+++ b/app/Http/Controllers/Admin/IndikatorKelulusanController.php
@@ -18,7 +18,17 @@ class IndikatorKelulusanController extends Controller
     {
         $kategoris = IndikatorKelulusanKategori::with('allIndikators')->ordered()->get();
         $setting = IndikatorKelulusanSetting::getActive();
-        
+
+        // Create default setting if none exists to ensure the page loads with data
+        if (!$setting) {
+            $setting = IndikatorKelulusanSetting::create([
+                'judul_utama'      => 'Indikator Kelulusan SDIT Luqman Al Hakim',
+                'judul_header'     => 'Indikator Kelulusan',
+                'deskripsi_header' => 'SD Islam Terpadu Luqman Al Hakim Sleman menerapkan indikator kelulusan sebagai tolak ukur keberhasilan pendidikan.',
+                'is_active'        => true,
+            ]);
+        }
+
         return view('admin.profil.indikator-kelulusan.index', compact('kategoris', 'setting'));
     }
 
@@ -97,7 +107,7 @@ class IndikatorKelulusanController extends Controller
      */
     public function createKategori()
     {
-        return view('admin.indikator-kelulusan.create-kategori');
+        return view('admin.profil.indikator-kelulusan.create-kategori');
     }
 
     /**
@@ -139,7 +149,7 @@ class IndikatorKelulusanController extends Controller
     public function editKategori($id)
     {
         $kategori = IndikatorKelulusanKategori::findOrFail($id);
-        return view('admin.indikator-kelulusan.edit-kategori', compact('kategori'));
+        return view('admin.profil.indikator-kelulusan.edit-kategori', compact('kategori'));
     }
 
     /**
@@ -218,7 +228,7 @@ class IndikatorKelulusanController extends Controller
     public function createIndikator()
     {
         $kategoris = IndikatorKelulusanKategori::active()->ordered()->get();
-        return view('admin.indikator-kelulusan.create-indikator', compact('kategoris'));
+        return view('admin.profil.indikator-kelulusan.create-indikator', compact('kategoris'));
     }
 
     /**
@@ -263,7 +273,7 @@ class IndikatorKelulusanController extends Controller
     {
         $indikator = IndikatorKelulusan::with('kategori')->findOrFail($id);
         $kategoris = IndikatorKelulusanKategori::active()->ordered()->get();
-        return view('admin.indikator-kelulusan.edit-indikator', compact('indikator', 'kategoris'));
+        return view('admin.profil.indikator-kelulusan.edit-indikator', compact('indikator', 'kategoris'));
     }
 
     /**


### PR DESCRIPTION
Standardize Indikator Kelulusan admin views and ensure default data to align with other Profile menus.

This PR corrects view paths for Indikator Kelulusan to be under `admin.profil` for consistency with other profile sections (e.g., Kurikulum). It also adds logic to automatically create default settings for Indikator Kelulusan if none exist, ensuring the page always displays initial data as required by the task.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3f9182d-5595-40ff-b804-d837709e9163">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3f9182d-5595-40ff-b804-d837709e9163">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

